### PR TITLE
Remove trailing comma from specification

### DIFF
--- a/PullToRefreshCoreText.podspec
+++ b/PullToRefreshCoreText.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "PullToRefreshCoreText"
   s.version      = "0.2"
-  s.summary      = "PullToRefresh extension for all UIScrollView type classes with animated text drawing style ",
+  s.summary      = "PullToRefresh extension for all UIScrollView type classes with animated text drawing style "
   s.description = <<-DESC
                 https://github.com/cemolcay/PullToRefreshCoreText/blob/master/README.md
                    DESC


### PR DESCRIPTION
This is actually not valid, see CocoaPods/CocoaPods#3134 - a future version of `pod lib lint` should catch it.