### PR TITLE
Fix positioning on orientation change

### DIFF
--- a/PullToRefreshCoreText.xcodeproj/project.pbxproj
+++ b/PullToRefreshCoreText.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B2D4613119F006ED00C6B60A /* Mask.png in Resources */ = {isa = PBXBuildFile; fileRef = B2D4612C19F006ED00C6B60A /* Mask.png */; };
 		B2D4613219F006ED00C6B60A /* PullToRefreshCoreTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D4612E19F006ED00C6B60A /* PullToRefreshCoreTextView.m */; };
 		B2D4613319F006ED00C6B60A /* UIScrollView+PullToRefreshCoreText.m in Sources */ = {isa = PBXBuildFile; fileRef = B2D4613019F006ED00C6B60A /* UIScrollView+PullToRefreshCoreText.m */; };
+		C00613BA1C10F7DC00E38B9E /* TableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C00613B91C10F7DC00E38B9E /* TableViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +49,8 @@
 		B2D4612E19F006ED00C6B60A /* PullToRefreshCoreTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PullToRefreshCoreTextView.m; sourceTree = "<group>"; };
 		B2D4612F19F006ED00C6B60A /* UIScrollView+PullToRefreshCoreText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+PullToRefreshCoreText.h"; sourceTree = "<group>"; };
 		B2D4613019F006ED00C6B60A /* UIScrollView+PullToRefreshCoreText.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+PullToRefreshCoreText.m"; sourceTree = "<group>"; };
+		C00613B81C10F7DC00E38B9E /* TableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TableViewController.h; sourceTree = "<group>"; };
+		C00613B91C10F7DC00E38B9E /* TableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +97,8 @@
 				B29BC27B19E4178E00365B69 /* AppDelegate.m */,
 				B29BC27D19E4178E00365B69 /* ViewController.h */,
 				B29BC27E19E4178E00365B69 /* ViewController.m */,
+				C00613B81C10F7DC00E38B9E /* TableViewController.h */,
+				C00613B91C10F7DC00E38B9E /* TableViewController.m */,
 				B29BC28019E4178E00365B69 /* Main.storyboard */,
 				B29BC28319E4178E00365B69 /* Images.xcassets */,
 				B29BC28519E4178E00365B69 /* LaunchScreen.xib */,
@@ -242,6 +247,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B29BC27F19E4178E00365B69 /* ViewController.m in Sources */,
+				C00613BA1C10F7DC00E38B9E /* TableViewController.m in Sources */,
 				B29BC27C19E4178E00365B69 /* AppDelegate.m in Sources */,
 				B2D4613219F006ED00C6B60A /* PullToRefreshCoreTextView.m in Sources */,
 				B2D4613319F006ED00C6B60A /* UIScrollView+PullToRefreshCoreText.m in Sources */,

--- a/PullToRefreshCoreText.xcodeproj/project.pbxproj
+++ b/PullToRefreshCoreText.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 				INFOPLIST_FILE = PullToRefreshCoreText/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -380,6 +381,7 @@
 				INFOPLIST_FILE = PullToRefreshCoreText/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/PullToRefreshCoreText/Base.lproj/Main.storyboard
+++ b/PullToRefreshCoreText/Base.lproj/Main.storyboard
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="14A238x" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Y88-L3-P6Y">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
         <scene sceneID="2Ro-rl-dna">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Lea-LT-KEP" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController id="BfW-tV-ppi" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="it7-Wk-oHz">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="vXZ-lx-hvc" kind="relationship" relationship="rootViewController" id="dPq-b0-8jO"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Lea-LT-KEP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1772" y="-184"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
                 <viewController id="vXZ-lx-hvc" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
@@ -32,12 +33,54 @@
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" id="jga-Oo-vkh"/>
                 </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1063" y="-175"/>
+        </scene>
+        <!--TableView-->
+        <scene sceneID="nyJ-hi-JwI">
+            <objects>
+                <tableViewController id="NYm-Sv-Ubr" customClass="TableViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="LWD-fS-cgE">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections/>
+                        <connections>
+                            <outlet property="dataSource" destination="NYm-Sv-Ubr" id="LmZ-hJ-wt0"/>
+                            <outlet property="delegate" destination="NYm-Sv-Ubr" id="Kln-sd-eCv"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="TableView" id="lqh-9m-icR"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Jfr-ZC-dYh" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1063" y="570"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="trH-2U-2BI">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Y88-L3-P6Y" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="IIp-nV-0DY">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <animations/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="NYm-Sv-Ubr" kind="relationship" relationship="rootViewController" id="nlG-0J-7zX"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Jrw-8w-Osb" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1772" y="570"/>
         </scene>
     </scenes>
 </document>

--- a/PullToRefreshCoreText/Info.plist
+++ b/PullToRefreshCoreText/Info.plist
@@ -39,6 +39,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>

--- a/PullToRefreshCoreText/PullToRefreshCoreText/PullToRefreshCoreTextView.h
+++ b/PullToRefreshCoreText/PullToRefreshCoreText/PullToRefreshCoreTextView.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, PullToRefreshCoreTextStatus) {
 @property (nonatomic, strong) UIFont *refreshingTextFont;
 
 
-@property (nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, weak) UIScrollView *scrollView;
 @property (nonatomic, assign) CGFloat triggerOffset;
 @property (nonatomic, assign) CGFloat triggerThreshold;
 

--- a/PullToRefreshCoreText/PullToRefreshCoreText/PullToRefreshCoreTextView.m
+++ b/PullToRefreshCoreText/PullToRefreshCoreText/PullToRefreshCoreTextView.m
@@ -130,7 +130,11 @@
     CATextLayer *text = [CATextLayer layer];
     [text setFrame:self.bounds];
     [text setString:(id)self.refreshingText];
-    [text setFont:CTFontCreateWithName((__bridge CFStringRef)self.refreshingTextFont.fontName, self.refreshingTextFont.pointSize, NULL)];
+    
+    CTFontRef fontRef = CTFontCreateWithName((__bridge CFStringRef)self.refreshingTextFont.fontName, self.refreshingTextFont.pointSize, NULL);
+    [text setFont:fontRef];
+    CFRelease(fontRef);
+    
     [text setFontSize:self.refreshingTextFont.pointSize];
     [text setForegroundColor:[self.refreshingTextColor CGColor]];
     [text setContentsScale:[[UIScreen mainScreen] scale]];

--- a/PullToRefreshCoreText/PullToRefreshCoreText/PullToRefreshCoreTextView.m
+++ b/PullToRefreshCoreText/PullToRefreshCoreText/PullToRefreshCoreTextView.m
@@ -158,6 +158,19 @@
 #pragma mark - Interaction
 
 - (void)scrollViewDidScroll:(UIPanGestureRecognizer *)pan {
+    
+    // Check if the superview's frame width has changed.
+    if (self.superview.bounds.size.width != self.frame.size.width) {
+        
+        // Update our frame with the new width.
+        CGRect newFrame = self.frame;
+        newFrame.size.width = self.superview.bounds.size.width;
+        self.frame = newFrame;
+        
+        // Update the layers.
+        [self setLoading:self.isLoading];
+    }
+    
     if (pan.state == UIGestureRecognizerStateChanged) {
         if (self.isLoading)
             return;

--- a/PullToRefreshCoreText/TableViewController.h
+++ b/PullToRefreshCoreText/TableViewController.h
@@ -1,0 +1,13 @@
+//
+//  TableViewController.h
+//  PullToRefreshCoreText
+//
+//  Created by Codi Bonney on 12/3/15.
+//  Copyright © 2015 questa. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface TableViewController : UITableViewController
+
+@end

--- a/PullToRefreshCoreText/TableViewController.m
+++ b/PullToRefreshCoreText/TableViewController.m
@@ -1,0 +1,84 @@
+//
+//  TableViewController.m
+//  PullToRefreshCoreText
+//
+//  Created by Codi Bonney on 12/3/15.
+//  Copyright © 2015 questa. All rights reserved.
+//
+
+#import "TableViewController.h"
+#import "UIScrollView+PullToRefreshCoreText.h"
+
+static NSString* const KCellIdentifier = @"PTRCTTableCell";
+
+@interface TableViewController ()
+@property (nonatomic) NSMutableArray* datasource;
+@end
+
+@implementation TableViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.datasource = [NSMutableArray new];
+    
+    // TODO: add support for UIRectEdgeAll
+    self.edgesForExtendedLayout = UIRectEdgeNone;
+    
+    //add pull to refresh
+    __weak typeof(self) weakSelf = self;
+    [self.tableView addPullToRefreshWithPullText:@"Pull To Refresh" pullTextColor:[UIColor blackColor] pullTextFont:DefaultTextFont refreshingText:@"Refreshing" refreshingTextColor:[UIColor blueColor] refreshingTextFont:DefaultTextFont action:^{
+        [weakSelf loadItems];
+    }];
+    
+    //add some items to scroll view
+    for (int i = 0; i < 2; i++) {
+        [self addNewItem];
+    }    
+}
+
+- (void)loadItems {
+    __weak typeof(UIScrollView *) weakScrollView = self.tableView;
+    __weak typeof(self) weakSelf = self;
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC);
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+        [weakSelf addNewItem];
+        [weakScrollView finishLoading];
+    });
+}
+
+- (void)addNewItem {
+    [self.datasource addObject:[self randomColor]];
+    [self.tableView reloadData];
+}
+
+- (UIColor *)randomColor {
+    CGFloat hue = ( arc4random() % 256 / 256.0 );  //  0.0 to 1.0
+    CGFloat saturation = ( arc4random() % 128 / 256.0 ) + 0.5;  //  0.5 to 1.0, away from white
+    CGFloat brightness = ( arc4random() % 128 / 256.0 ) + 0.5;  //  0.5 to 1.0, away from black
+    return [UIColor colorWithHue:hue saturation:saturation brightness:brightness alpha:1];
+}
+
+#pragma mark - UITableView DataSource
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView{
+    return 1;
+}
+
+-(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
+    return self.datasource.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
+    UITableViewCell* cell = [tableView dequeueReusableCellWithIdentifier:KCellIdentifier];
+    if (!cell) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:KCellIdentifier];
+    }
+    
+    cell.textLabel.text = @(indexPath.row+1).stringValue;
+    cell.backgroundColor = self.datasource[indexPath.row];
+    
+    return cell;
+}
+
+
+@end


### PR DESCRIPTION
When the orientation changes the width of the PullToRefreshCoreTextView's superview will change. I perform a check for this when the scrollview begins to scroll and update the view's frame and it's layers.

Additionally, I added a UITableViewController example.
